### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM nginx:alpine
-
-RUN rm -rf /usr/share/nginx/html
-
-COPY ./js /usr/share/nginx/html
-
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+    calla:
+        image: nginx:alpine
+        volumes:
+            - ./js:/usr/share/nginx/html
+        command: sh /usr/share/nginx/html/entrypoint.sh 
+

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,3 @@
+const JITSI_HOST = "jitsi" + window.location.hostname.substring(window.location.hostname.indexOf('.'));
+const JVB_HOST = "meet.jitsi";
+const JVB_MUC = "muc.meet.jitsi";

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,3 +1,3 @@
-const JITSI_HOST = "jitsi" + window.location.hostname.substring(window.location.hostname.indexOf('.'));
-const JVB_HOST = "meet.jitsi";
-const JVB_MUC = "muc.meet.jitsi";
+const JITSI_HOST = "jitsi.calla.chat";
+const JVB_HOST = JITSI_HOST;
+const JVB_MUC = "conference." + JITSI_HOST;

--- a/js/entrypoint.sh
+++ b/js/entrypoint.sh
@@ -1,0 +1,17 @@
+DIRECTORY=$(cd `dirname $0` && pwd)
+
+if [[ $JITSI_HOST ]]; then
+  JITSI_HOST="\"$JITSI_HOST\""
+else
+  JITSI_HOST='"jitsi" + window.location.hostname.substring(window.location.hostname.indexOf("."))'
+fi
+DEFAULT_JVB_HOST='meet.jitsi'
+DEFAULT_JVB_MUC='muc.meet.jitsi'
+
+cat > $DIRECTORY/constants.js <<- EOF
+const JITSI_HOST = $JITSI_HOST;
+const JVB_HOST = "${JVB_HOST:-$DEFAULT_JVB_HOST}";
+const JVB_MUC = "${JVB_MUC:-$DEFAULT_JVB_MUC}";
+EOF
+
+exec nginx -g "daemon off;"

--- a/js/index.html
+++ b/js/index.html
@@ -41,7 +41,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <script id="app-settings">
-        const JITSI_HOST = "jitsi.calla.chat";
+        const JITSI_HOST = "jitsi" + window.location.hostname.substring(window.location.hostname.indexOf('.'));
     </script>
 
     <link type="text/css" rel="stylesheet" href="/stylesheets/general.css" />

--- a/js/index.html
+++ b/js/index.html
@@ -40,9 +40,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png">
     <link rel="manifest" href="/manifest.json">
 
-    <script id="app-settings">
-        const JITSI_HOST = "jitsi" + window.location.hostname.substring(window.location.hostname.indexOf('.'));
-    </script>
+    <script id="app-settings" src="/constants.js"></script>
 
     <link type="text/css" rel="stylesheet" href="/stylesheets/general.css" />
     <link type="text/css" rel="stylesheet" href="/stylesheets/icons.css" />

--- a/js/src/jitsi/LibJitsiMeetClient.js
+++ b/js/src/jitsi/LibJitsiMeetClient.js
@@ -70,8 +70,8 @@ export class LibJitsiMeetClient extends BaseJitsiClient {
 
         this.connection = new JitsiMeetJS.JitsiConnection(null, null, {
             hosts: {
-                domain: host,
-                muc: `conference.${host}`
+                domain: 'meet.jitsi',
+                muc: 'muc.meet.jitsi'
             },
             serviceUrl: `https://${host}/http-bind`,
             enableLipSync: true

--- a/js/src/jitsi/LibJitsiMeetClient.js
+++ b/js/src/jitsi/LibJitsiMeetClient.js
@@ -70,8 +70,8 @@ export class LibJitsiMeetClient extends BaseJitsiClient {
 
         this.connection = new JitsiMeetJS.JitsiConnection(null, null, {
             hosts: {
-                domain: 'meet.jitsi',
-                muc: 'muc.meet.jitsi'
+                domain: JVB_HOST,
+                muc: JVB_MUC
             },
             serviceUrl: `https://${host}/http-bind`,
             enableLipSync: true


### PR DESCRIPTION
Updated the install instructions for lib-jitsi-meet instead of the external api.  This required pulling some path variables into a separate constants.js so that they can be overwritten by environment variables as necessary.  The original defaults are kept in constants.js, although I think `JITSI_HOST` can be set to 

    "jitsi" + window.location.hostname.substring(window.location.hostname.indexOf("."))

without any change in functionality, thus removing the hardcoded `calla.chat` domain.