### PR TITLE
Fix user videos positioning and add usage example 

### DIFF
--- a/Calla/doc/basic/Tutorial.md
+++ b/Calla/doc/basic/Tutorial.md
@@ -91,6 +91,7 @@ Make the configuration controls line up nice.
 Make the clickable space of the page visible to the user.
 ```css
 #space {
+    position: relative;
     background-color: #ccc;
     border: inset 2px;
     overflow: hidden;
@@ -104,7 +105,7 @@ Every user is going to have their own DIV with their user name and video display
 
 We want the user blocks to be clipped by the space container, and positioned inside of it.
 ```css
-    position: relative;
+    position: absolute;
 ```
 
 Don't make user blocks too large or the motion doesn't feel right.
@@ -258,13 +259,13 @@ I've also added a parameter for indicating when the user is the local user, so w
     constructor(id, name, pose, isLocal) {
         /**
          * The user's name.
-         * @type {string} 
+         * @type {string}
          **/
         this._name = null;
 
         /**
          * An HTML element to display the user's name.
-         * @type {HTMLDivElement} 
+         * @type {HTMLDivElement}
          **/
         this._nameEl = null;
 
@@ -380,8 +381,8 @@ Let's start setting up an application.
 ### Import Calla
 Strictly speaking, only importing the `CallaClient` is necessary, but there are some other, useful elements as well.
 ```javascript
-import { 
-  CallaClient, // required  
+import {
+  CallaClient, // required
   canChangeAudioOutput // Will be use to enable/disable the audio output selector
 } from "calla";
 ```
@@ -583,7 +584,7 @@ Start the renderer
     timer = requestAnimationFrame(update);
 ```
 
-Create a user graphic for the local user (see below). 
+Create a user graphic for the local user (see below).
 ```javascript
     addUser(id, displayName, pose, true);
 ```
@@ -591,7 +592,7 @@ Create a user graphic for the local user (see below).
 For testing purposes, we place the user at a random location  on the page. Ideally, you'd have a starting location for users so you could design a predictable onboarding path for them (see below).
 ```javascript
     setPosition(
-      Math.random() * (controls.space.clientWidth - 100) + 50, 
+      Math.random() * (controls.space.clientWidth - 100) + 50,
       Math.random() * (controls.space.clientHeight - 100) + 50);
 });
 ```

--- a/Calla/doc/basic/example/index.html
+++ b/Calla/doc/basic/example/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, shrink-to-fit=0, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
+    />
+    <title>Minimum Calla Setup</title>
+    <script type="module" src="main.js"></script>
+    <style type="text/css">
+      * {
+        box-sizing: border-box;
+        font-family: -apple-system, ".SFNSText-Regular", "San Francisco",
+          "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif;
+      }
+
+      html,
+      body {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+      }
+
+      body {
+        display: grid;
+        grid-template-rows: 1fr auto auto auto;
+        padding: 1em;
+        grid-row-gap: 1em;
+        grid-column-gap: 1em;
+        row-gap: 1em;
+        column-gap: 1em;
+      }
+
+      .user {
+        position: absolute;
+        width: 10em;
+        border-width: 2px;
+        border-style: solid;
+        border-color: #888;
+        background-color: #eee;
+        padding: 5px;
+        box-shadow: rgba(0, 0, 0, 0.5) 5px 5px 10px;
+      }
+
+      .localUser {
+        border-color: #383;
+        background-color: #8e8;
+      }
+
+      .userName {
+        text-align: center;
+      }
+
+      .userVideo {
+        max-width: 100%;
+      }
+
+      .localUser > .userVideo {
+        transform: scaleX(-1);
+      }
+
+      #controls {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        grid-column-gap: 0.5em;
+        column-gap: 0.5em;
+      }
+
+      #controls > label {
+        text-align: right;
+      }
+
+      #controls > select {
+        width: 100%;
+      }
+
+      #space {
+        position: relative;
+        margin-left: 30px;
+        background-color: #ccc;
+        border: inset 2px;
+        overflow: hidden;
+      }
+
+      footer {
+        text-align: right;
+        color: #333;
+        font-size: 75%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="space"></div>
+    <form id="controls" autocomplete="on">
+      <label for="roomName">Room:</label>
+      <input
+        id="roomName"
+        type="text"
+        placeholder="(Required)"
+        value="TestRoom"
+      />
+
+      <label for="userName">User:</label>
+      <input
+        id="userName"
+        placeholder="(Required)"
+        type="text"
+        value="TestUser"
+      />
+
+      <label for="cams">Video:</label>
+      <select id="cams"></select>
+
+      <label for="mics">Microphone:</label>
+      <select id="mics"></select>
+
+      <label for="speakers">Speakers:</label>
+      <select id="speakers"></select>
+    </form>
+    <div>
+      <button type="button" id="connect" disabled>Connect</button>
+      <button type="button" id="leave" disabled>Leave</button>
+      <button type="button" id="sideTest">Open side test</button>
+    </div>
+    <footer>
+      <a href="https://www.calla.chat">Calla</a> is made with glue and tenacity
+      at <a href="https://www.dlsdc.com">Diplomatic Language Services</a>.
+    </footer>
+  </body>
+</html>

--- a/Calla/doc/basic/example/main.js
+++ b/Calla/doc/basic/example/main.js
@@ -1,0 +1,298 @@
+const controls = Array.prototype.reduce.call(
+  document.querySelectorAll("[id]"),
+  (ctrls, elem) => {
+    ctrls[elem.id] = elem;
+    return ctrls;
+  },
+  {}
+);
+
+export const JITSI_HOST = "beta.meet.jit.si";
+export const JVB_HOST = JITSI_HOST;
+export const JVB_MUC = "conference." + JITSI_HOST;
+
+class User {
+  constructor(id, name, pose, isLocal) {
+    /**
+     * The user's name.
+     * @type {string}
+     **/
+    this._name = null;
+
+    /**
+     * An HTML element to display the user's name.
+     * @type {HTMLDivElement}
+     **/
+    this._nameEl = null;
+
+    /**
+     * Calla will eventually give us a video stream for the user.
+     * @type {MediaStream}
+     **/
+    this._videoStream = null;
+
+    /**
+     * An HTML element for displaying the user's video.
+     * @type {HTMLVideoElement}
+     **/
+    this._video = null;
+
+    /**
+     * An HTML element for showing the user name and video together.
+     **/
+    this.container = document.createElement("div");
+    this.container.className = "user";
+    if (isLocal) {
+      this.container.className += " localUser";
+      name += " (Me)";
+    }
+
+    this.id = id;
+    this.name = name;
+    this.pose = pose;
+  }
+
+  dispose() {
+    this.container.parentElement.removeChild(this.container);
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  set name(v) {
+    if (this._nameEl) {
+      this.container.removeChild(this._nameEl);
+      this._nameEl = null;
+    }
+    this._name = v;
+    this._nameEl = document.createElement("div");
+    this._nameEl.className = "userName";
+    this._nameEl.append(document.createTextNode(this.name));
+    this.container.append(this._nameEl);
+  }
+
+  get videoStream() {
+    return this._videoStream;
+  }
+
+  set videoStream(v) {
+    // make sure to remove any existing video elements, first. This
+    // will occur if the user changes their video input device.
+    if (this._video) {
+      this.container.removeChild(this._video);
+      this._video = null;
+    }
+
+    this._videoStream = v;
+
+    if (this._videoStream) {
+      this._video = document.createElement("video");
+      this._video.className = "userVideo";
+      this.container.append(this._video);
+
+      // a bunch of settings to make the video play right
+      this._video.playsInline = true;
+      this._video.autoplay = true;
+      this._video.controls = false;
+      this._video.muted = true;
+      this._video.volume = 0;
+
+      // now start the video
+      this._video.srcObject = this._videoStream;
+      this._video.play();
+    }
+  }
+
+  update() {
+    window.test = this.container;
+    const dx =
+      this.container.parentElement.clientLeft - this.container.clientWidth / 2;
+    const dy =
+      this.container.parentElement.clientTop - this.container.clientHeight / 2;
+    this.container.style.left = 100 * this.pose.current.p.x + dx + "px";
+    this.container.style.zIndex = this.pose.current.p.y;
+    this.container.style.top = 100 * this.pose.current.p.z + dy + "px";
+  }
+}
+
+import { CallaClient, canChangeAudioOutput } from "./calla.js";
+
+const client = new CallaClient(JITSI_HOST, JVB_HOST, JVB_MUC);
+const users = new Map();
+
+(async function () {
+  deviceSelector(
+    true,
+    controls.cams,
+    await client.getVideoInputDevicesAsync(),
+    await client.getPreferredVideoInputAsync(true),
+    (device) => client.setVideoInputDeviceAsync(device)
+  );
+  deviceSelector(
+    true,
+    controls.mics,
+    await client.getAudioInputDevicesAsync(),
+    await client.getPreferredAudioInputAsync(true),
+    (device) => client.setAudioInputDeviceAsync(device)
+  );
+  deviceSelector(
+    false,
+    controls.speakers,
+    await client.getAudioOutputDevicesAsync(),
+    await client.getPreferredAudioOutputAsync(true),
+    (device) => client.setAudioOutputDeviceAsync(device)
+  );
+  controls.speakers.disabled = !canChangeAudioOutput;
+})();
+
+function deviceSelector(addNone, select, values, preferredDevice, onSelect) {
+  if (addNone) {
+    const none = document.createElement("option");
+    none.text = "None";
+    select.append(none);
+  }
+  select.append(
+    ...values.map((value) => {
+      const opt = document.createElement("option");
+      opt.value = value.deviceId;
+      opt.text = value.label;
+      if (preferredDevice && preferredDevice.deviceId === value.deviceId) {
+        opt.selected = true;
+      }
+      return opt;
+    })
+  );
+  select.addEventListener("input", () => {
+    let idx = select.selectedIndex;
+
+    // Skip the vestigial "none" item.
+    if (addNone) {
+      --idx;
+    }
+
+    const value = values[idx];
+    onSelect(value || null);
+  });
+  onSelect(preferredDevice);
+}
+controls.connect.disabled = false;
+
+controls.connect.addEventListener("click", connect);
+function connect() {
+  const roomName = controls.roomName.value;
+  const userName = controls.userName.value;
+
+  let message = "";
+  if (roomName.length === 0) {
+    message += "\n   Room name is required";
+  }
+  if (userName.length === 0) {
+    message += "\n   User name is required";
+  }
+
+  if (message.length > 0) {
+    message = "Required fields missing:" + message;
+    alert(message);
+    return;
+  }
+  controls.roomName.disabled = true;
+  controls.userName.disabled = true;
+  controls.connect.disabled = true;
+  // client.startAudio();
+  client.join(roomName, userName);
+}
+let timer = null;
+
+client.addEventListener("videoConferenceJoined", (evt) => {
+  const { id, displayName, pose } = evt;
+
+  controls.leave.disabled = false;
+
+  timer = requestAnimationFrame(update);
+
+  addUser(id, displayName, pose, true);
+  setPosition(
+    Math.random() * (controls.space.clientWidth - 100) + 50,
+    Math.random() * (controls.space.clientHeight - 100) + 50
+  );
+});
+
+controls.leave.addEventListener("click", () => client.leaveAsync());
+client.addEventListener("videoConferenceLeft", () => {
+  removeUser(client.localUserID);
+
+  cancelAnimationFrame(timer);
+
+  controls.leave.disabled = true;
+  controls.connect.disabled = false;
+});
+
+client.addEventListener("participantJoined", (evt) => {
+  const { id, displayName, pose } = evt;
+  addUser(id, displayName, pose, false);
+});
+client.addEventListener("participantLeft", (evt) => {
+  const { id } = evt;
+  removeUser(id);
+});
+function addUser(id, name, pose, isLocal) {
+  if (users.has(id)) {
+    users.get(id).dispose();
+  }
+
+  const user = new User(id, name, pose, isLocal);
+
+  controls.space.append(user.container);
+
+  users.set(id, user);
+}
+function removeUser(id) {
+  if (users.has(id)) {
+    const user = users.get(id);
+    user.dispose();
+    users.delete(id);
+  }
+}
+function update() {
+  timer = requestAnimationFrame(update);
+
+  client.update();
+
+  for (let user of users.values()) {
+    user.update();
+  }
+}
+controls.space.addEventListener("click", (evt) => {
+  const x = evt.clientX - controls.space.offsetLeft;
+  const y = evt.clientY - controls.space.offsetTop;
+  setPosition(x, y);
+});
+function setPosition(x, y) {
+  if (client.localUserID) {
+    x /= 100;
+    y /= 100;
+
+    client.setLocalPosition(x, 0, y);
+  }
+}
+client.addEventListener("displayNameChange", (evt) => {
+  const { id, displayName } = evt;
+  changeName(id, displayName);
+});
+function changeName(id, displayName) {
+  if (users.has(id)) {
+    const user = users.get(id);
+    user.name = displayName;
+  }
+}
+client.addEventListener("videoChanged", (evt) => {
+  const { id, stream } = evt;
+  changeVideo(id, stream);
+});
+function changeVideo(id, stream) {
+  if (users.has(id)) {
+    const user = users.get(id);
+    user.videoStream = stream;
+  }
+}


### PR DESCRIPTION
Fix bug in video positioning by changing the CSS property ```position``` of the space container into ```relative``` and the user divs into ```absolute```.
A complete example extracted from the tutorial is proposed, to ease reproducibility without requiring to copy and paste pieces of code from the tutorial.